### PR TITLE
implemented alt_bn128_G1_neg

### DIFF
--- a/include/Snark/Snark.h
+++ b/include/Snark/Snark.h
@@ -40,5 +40,5 @@ bytes alt_bn128_G1_mul(bytesConstRef p1, bytesConstRef s);
 // p1 and p2 are 64 byte values, representing points (x, y),
 // where each of x and y are 32 byte big-endian numbers
 bytes alt_bn128_G1_add(bytesConstRef p1, bytesConstRef p2);
-// p1 is a 64 byte value (representing point (x, y))
+// p is a 64 byte value (representing point (x, y))
 bytes alt_bn128_G1_neg(bytesConstRef p);

--- a/include/Snark/Snark.h
+++ b/include/Snark/Snark.h
@@ -40,3 +40,5 @@ bytes alt_bn128_G1_mul(bytesConstRef p1, bytesConstRef s);
 // p1 and p2 are 64 byte values, representing points (x, y),
 // where each of x and y are 32 byte big-endian numbers
 bytes alt_bn128_G1_add(bytesConstRef p1, bytesConstRef p2);
+// p1 is a 64 byte value (representing point (x, y))
+bytes alt_bn128_G1_neg(bytesConstRef p);

--- a/lib/Snark/Snark.cpp
+++ b/lib/Snark/Snark.cpp
@@ -187,3 +187,13 @@ bytes alt_bn128_G1_mul(bytesConstRef _p1, bytesConstRef _s)
   libff::alt_bn128_G1 const result = toLibsnarkBigint(_s) * p;
   return encodePointG1(result);
 }
+
+bytes alt_bn128_G1_neg(bytesConstRef _p)
+{
+  if (_p.size() != 64)
+    throw SnarkExn("Snark: alt_bn128_G1_neg: Invalid input");
+
+  initLibSnark();
+  libff::alt_bn128_G1 const p = decodePointG1(_p);
+  return encodePointG1(-p);
+}


### PR DESCRIPTION
followed the same flow as `mul` and `add`

- check point size 64
- call `initLibSnark()`
- decode and encode point

I'm not sure how to test the code but it looks like it should work fine, will need some input regarding this.