### PR TITLE
Base point multiplication / Multiply scalar to generator

### DIFF
--- a/include/Snark/Snark.h
+++ b/include/Snark/Snark.h
@@ -37,6 +37,9 @@ bytes alt_bn128_pairing_product(bytesConstRef in);
 // p1 is a 64 byte value (representing point (x, y)), and
 // s is a scalar, a 32 byte big-endian number
 bytes alt_bn128_G1_mul(bytesConstRef p1, bytesConstRef s);
+// multiply scalar to base point / generator of group
+// s is a scalar, a 32 byte big-endian number
+bytes alt_bn128_G1_bmul(bytesConstRef s);
 // p1 and p2 are 64 byte values, representing points (x, y),
 // where each of x and y are 32 byte big-endian numbers
 bytes alt_bn128_G1_add(bytesConstRef p1, bytesConstRef p2);

--- a/lib/Snark/Snark.cpp
+++ b/lib/Snark/Snark.cpp
@@ -196,6 +196,7 @@ bytes alt_bn128_G1_bmul(bytesConstRef _s) {
   libff::alt_bn128_G1 const p = libff::alt_bn128_G1::one();
   libff::alt_bn128_G1 const result = toLibsnarkBigint(_s) * p;
   return encodePointG1(result);
+}
 
 bytes alt_bn128_G1_neg(bytesConstRef _p)
 {

--- a/lib/Snark/Snark.cpp
+++ b/lib/Snark/Snark.cpp
@@ -187,3 +187,13 @@ bytes alt_bn128_G1_mul(bytesConstRef _p1, bytesConstRef _s)
   libff::alt_bn128_G1 const result = toLibsnarkBigint(_s) * p;
   return encodePointG1(result);
 }
+
+bytes alt_bn128_G1_bmul(bytesConstRef _s) {
+  if ( _s.size() != 32)
+    throw SnarkExn("Snark: alt_bn128_G1_bmul: Invalid input");
+  
+  initLibSnark();
+  libff::alt_bn128_G1 const p = libff::alt_bn128_G1::one();
+  libff::alt_bn128_G1 const result = toLibsnarkBigint(_s) * p;
+  return encodePointG1(result);
+}


### PR DESCRIPTION
Implemented multiplication function to generator : `alt_bn128_G1_bmul`

Useful for given private key `x`, derive its public key `g^x` via `alt_bn128_G1_bmul(x)`

Can also be used to derive point at infinity or identity via `alt_bn128_G1_bmul(zero)`

To be used in implementing a builtin in scilla