### PR TITLE
ZIL-4812: update the libff submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "depends/libff"]
 	path = depends/libff
-	url = https://github.com/scipr-lab/libff
+	url = https://github.com/Zilliqa/libff


### PR DESCRIPTION
libff has been forked and added a condition in its CMakeLists.txt to skip compilation of the zm lib if building on ARM. For x86 there's no change.