### PR TITLE
Add vcpkg generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@
 # Build and install directories
 build/
 install/
+vcpkg-registry/
+vcpkg-configuration.json
+vcpkg.json


### PR DESCRIPTION
The files generated by `vcpkg` is creating noise in the scilla repo, so I've added them to `.gitignore` here.